### PR TITLE
Fix models and timezone class

### DIFF
--- a/API-Minimizer/MinimizerModel/MinimizerCommon/Commons/Tarjetas.cs
+++ b/API-Minimizer/MinimizerModel/MinimizerCommon/Commons/Tarjetas.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+
+namespace MinimizerCommon.Commons
+{
+    /// <summary>
+    /// Represents a simple credit or debit card entity.
+    /// </summary>
+    public class Tarjetas
+    {
+        public Tarjetas(int id, string name, string description, bool status, string cardNumber, string ccv)
+        {
+            if (string.IsNullOrWhiteSpace(ccv) || ccv.Length != 3 || !ccv.All(char.IsDigit))
+            {
+                throw new ArgumentException("CCV must be exactly 3 digits.");
+            }
+
+            Id = id;
+            Name = name;
+            Description = description;
+            Status = status;
+            CardNumber = cardNumber;
+            CCV = ccv;
+            CreatedAt = DateTime.Now;
+            UpdatedAt = DateTime.Now;
+        }
+
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public bool Status { get; set; }
+        public string CardNumber { get; set; }
+        public string CCV { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/API-Minimizer/MinimizerModel/MinimizerCommon/Commons/TimesZones.cs
+++ b/API-Minimizer/MinimizerModel/MinimizerCommon/Commons/TimesZones.cs
@@ -1,17 +1,31 @@
-namespace MinimizerCommon.Commons;
+using System;
+using System.Collections.Generic;
 
-    // add a class with array of time zones defined by two properties time and name of the time zone
-    public class TimesZones
+namespace MinimizerCommon.Commons
+{
+    /// <summary>
+    /// Represents a single timezone entry with a display name and time value.
+    /// </summary>
+    public class TimeZoneEntry
     {
-            // the constuctor will initialize the array with a time zones utc
-            public TimesZones()
-            {
-                TimeZones = new List<TimeZone>
-                {
-                    new TimeZone { Time = DateTime.Now.ToUniversalTime().ToString(), Name = "UTC" },
-                    new TimeZone { Time = DateTime.Now.AddHours(-5).ToString(), Name = "GMT-5" }
-                };
-            }
         public string Time { get; set; }
         public string Name { get; set; }
     }
+
+    /// <summary>
+    /// Provides a collection of common time zones.
+    /// </summary>
+    public class TimesZones
+    {
+        public TimesZones()
+        {
+            TimeZones = new List<TimeZoneEntry>
+            {
+                new TimeZoneEntry { Time = DateTime.UtcNow.ToString(), Name = "UTC" },
+                new TimeZoneEntry { Time = DateTime.UtcNow.AddHours(-5).ToString(), Name = "GMT-5" }
+            };
+        }
+
+        public List<TimeZoneEntry> TimeZones { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- implement missing `Tarjetas` model used by tests
- rewrite `TimesZones` with a proper timezone entry class

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb69808688328930e25123cf55594